### PR TITLE
A kieffer/fix multiple matches

### DIFF
--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Configuration.h
@@ -137,6 +137,7 @@ struct VertexingParameters {
   float phiCut = 0.005f; //0.005f
   float pairCut = 0.04f;
   float clusterCut = 0.8f;
+  float tanLambdaCut = 0.025f;
   int clusterContributorsCut = 16;
   int phiSpan = -1;
   int zSpan = -1;

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/IOUtils.h
@@ -61,6 +61,8 @@ void loadEventData(ROframe& events, const std::vector<itsmft::Cluster>* mCluster
                    const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
 int loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& events, const std::vector<itsmft::Cluster>* mClustersArray,
                     const dataformats::MCTruthContainer<MCCompLabel>* mClsLabels = nullptr);
+void generateSimpleData(ROframe& event, const int phiDivs, const int zDivs);
+
 
 std::vector<std::unordered_map<int, Label>> loadLabels(const int, const std::string&);
 void writeRoadsReport(std::ofstream&, std::ofstream&, std::ofstream&, const std::vector<std::vector<Road>>&,

--- a/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
+++ b/Detectors/ITSMFT/ITS/tracking/include/ITStracking/Vertexer.h
@@ -77,7 +77,7 @@ class Vertexer
   std::vector<Tracklet> getTracklets01() const;
   std::vector<Tracklet> getTracklets12() const;
   std::array<std::vector<Cluster>, 3> getClusters() const;
-  std::vector<std::array<float, 7>> getDeltaTanLambdas() const;
+  std::vector<std::array<float, 8>> getDeltaTanLambdas() const;
   std::vector<std::array<float, 4>> getCentroids() const;
   std::vector<std::array<float, 6>> getLinesData() const;
   void processLines(); 
@@ -177,7 +177,7 @@ inline std::array<std::vector<Cluster>, 3> Vertexer::getClusters() const
   return mTraits->mClusters;
 }
 
-inline std::vector<std::array<float, 7>> Vertexer::getDeltaTanLambdas() const
+inline std::vector<std::array<float, 8>> Vertexer::getDeltaTanLambdas() const
 {
   return mTraits->mDeltaTanlambdas;
 }

--- a/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/IOUtils.cxx
@@ -35,6 +35,9 @@ constexpr int PrimaryVertexLayerId{ -1 };
 constexpr int EventLabelsSeparator{ -1 };
 } // namespace
 
+using o2::its::constants::its::LayersRCoordinate;
+using o2::its::constants::its::LayersZCoordinate;
+
 namespace o2
 {
 namespace its
@@ -166,6 +169,45 @@ int ioutils::loadROFrameData(const o2::itsmft::ROFRecord& rof, ROframe& event, c
     clusterId++;
   }
   return number;
+}
+
+void ioutils::generateSimpleData(ROframe& event, const int phiDivs, const int zDivs = 0)
+{
+  const float angleOffset = constants::math::TwoPi / static_cast<float>(phiDivs);
+  // Maximum z allowed on innermost layer should be: ~9,75
+  const float zOffsetFirstLayer = (LayersZCoordinate()[2] * LayersRCoordinate()[0]) / (LayersRCoordinate()[2] * static_cast<float>(zDivs));
+  std::vector<float> x, y;
+  std::array<std::vector<float>, 3> z;
+  const int rZDiv = static_cast<int>(zDivs/2);
+  for (size_t j{ 0 }; j < rZDiv; ++j) {
+    for (size_t i{ 0 }; i < phiDivs; ++i) {
+      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
+      y.emplace_back(sin(i * angleOffset + 0.001));
+      const float zFirstLayer{ 2 * zOffsetFirstLayer * static_cast<float>(j) };
+      z[0].emplace_back(zFirstLayer);
+      z[1].emplace_back(zFirstLayer * LayersRCoordinate()[1] / LayersRCoordinate()[0]);
+      z[2].emplace_back(zFirstLayer * LayersRCoordinate()[2] / LayersRCoordinate()[0]);
+    }
+  }
+
+  for (size_t j{ 0 }; j < rZDiv; ++j) {
+    for (size_t i{ 0 }; i < phiDivs; ++i) {
+      x.emplace_back(cos(i * angleOffset + 0.001)); // put an epsilon to move from periods (e.g. 20 clusters vs 20 cells)
+      y.emplace_back(sin(i * angleOffset + 0.001));
+      const float zFirstLayer{ -zOffsetFirstLayer * 2 * static_cast<float>(j) };
+      z[0].emplace_back(zFirstLayer);
+      z[1].emplace_back(zFirstLayer * LayersRCoordinate()[1] / LayersRCoordinate()[0]);
+      z[2].emplace_back(zFirstLayer * LayersRCoordinate()[2] / LayersRCoordinate()[0]);
+    }
+  }
+
+  for (int iLayer{ 0 }; iLayer < constants::its::LayersNumberVertexer; ++iLayer) {
+    for (int i = 0; i < phiDivs * 2 * rZDiv; i++) {
+      o2::MCCompLabel label{ i, 0, 0, false };
+      event.addClusterLabelToLayer(iLayer, label);                                                                              //last argument : label, goes into mClustersLabel
+      event.addClusterToLayer(iLayer, LayersRCoordinate()[iLayer] * x[i], LayersRCoordinate()[iLayer] * y[i], z[iLayer][i], i); //uses 1st constructor for clusters
+    }
+  }
 }
 
 std::vector<std::unordered_map<int, Label>> ioutils::loadLabels(const int eventsNum, const std::string& fileName)

--- a/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
+++ b/Detectors/ITSMFT/ITS/tracking/src/VertexerTraits.cxx
@@ -126,6 +126,7 @@ void trackletSelectionKernelSerial(
   const std::vector<int>& MClabelsLayer1,
   const std::vector<int>& MClabelsLayer2,
   const float tanLambdaCut = 0.025f,
+  const float phiCut = 0.005f,
   const int maxTracklets = static_cast<int>(2e3))
 {
 
@@ -151,7 +152,8 @@ void trackletSelectionKernelSerial(
     for (int iTracklet12{ offset12 }; iTracklet12 < offset12 + foundTracklets12[iCurrentLayerClusterIndex]; ++iTracklet12) {
       for (int iTracklet01{ offset01 }; iTracklet01 < offset01 + foundTracklets01[iCurrentLayerClusterIndex]; ++iTracklet01) {
         const float deltaTanLambda{ gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].tanLambda - tracklets12[iTracklet12].tanLambda) };
-        if (deltaTanLambda < tanLambdaCut && validTracklets != maxTracklets) {
+        const float deltaPhi{ gpu::GPUCommonMath::Abs(tracklets01[iTracklet01].phiCoordinate - tracklets12[iTracklet12].phiCoordinate) };
+        if (deltaTanLambda < tanLambdaCut && deltaPhi < phiCut && validTracklets != maxTracklets) {
           ++validTracklets;
           ++totalTracklets;
           //there are only real tracklets
@@ -407,8 +409,9 @@ void VertexerTraits::computeTracklets(const bool useMCLabel)
     mDeltaTanlambdas,
     labelsMC0,
     labelsMC1,
-    labelsMC2
-    //mVrtParams.tanLambdaCut
+    labelsMC2,
+    mVrtParams.phiCut,
+    mVrtParams.tanLambdaCut
   );
 }
 

--- a/macro/run_primary_vertexer_ITS.C
+++ b/macro/run_primary_vertexer_ITS.C
@@ -90,14 +90,15 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   outTree.Branch("ITSVertices", &verticesITS);
 
   // DEBUG
-  TNtuple tracklets("Tracklets", "Tracklets", "oX:oY:oZ:c1:c2:c3:DCAvtx:DCAz");
-  TNtuple comb01("comb01", "comb01", "tanLambda:phi");
-  TNtuple comb12("comb12", "comb12", "tanLambda:phi");
-  TNtuple clusPhi01("clus_phi01", "clus_phi01", "phi0:phi1");
-  TNtuple clusPhi12("clus_phi12", "clus_phi12", "phi1:phi2");
-  TNtuple trackdeltaTanLambdas("dtl", "dtl", "deltatanlambda:c0z:c0r:c1z:c1r:c2z:c2r");
-  TNtuple centroids("centroids", "centroids", "id:x:y:z:dca");
-  TNtuple linesData("ld", "linesdata", "x:xy:xz:y:yz:z");
+  // TNtuple tracklets("Tracklets", "Tracklets", "oX:oY:oZ:c1:c2:c3:DCAvtx:DCAz");
+  // TNtuple comb01("comb01", "comb01", "tanLambda:phi");
+  // TNtuple comb12("comb12", "comb12", "tanLambda:phi");
+  // TNtuple clusPhi01("clus_phi01", "clus_phi01", "phi0:phi1");
+  // TNtuple clusPhi12("clus_phi12", "clus_phi12", "phi1:phi2");
+  // TNtuple trackdeltaTanLambdas("dtl", "dtl", "deltatanlambda:c0z:c0r:c1z:c1r:c2z:c2r:valid");
+  // TNtuple centroids("centroids", "centroids", "id:x:y:z:dca");
+  // TNtuple linesData("ld", "linesdata", "x:xy:xz:y:yz:z");
+  TNtuple numVerts("numVertices", "numvert", "numVert");
 
   std::uint32_t roFrame = 0;
 
@@ -114,61 +115,64 @@ int run_primary_vertexer_ITS(const bool useGPU = false,
   o2::its::Vertexer vertexer(traits);
 
   for (auto& rof : *rofs) {
+    
     itsClusters.GetEntry(rof.getROFEntry().getEvent());
     mcHeaderTree.GetEntry(rof.getROFEntry().getEvent());
-    int nclUsed = o2::its::ioutils::loadROFrameData(rof, frame, clusters, labels);
+    o2::its::ioutils::loadROFrameData(rof, frame, clusters, labels);
+    // o2::its::ioutils::generateSimpleData(frame, 16);
     // float total = vertexer.clustersToVertices(frame, true);
     vertexer.initialiseVertexer(&frame);
     vertexer.findTracklets(useMCcheck);
     // vertexer.findTrivialMCTracklets();
-    //     vertexer.processLines();
-    //     std::vector<std::array<float, 6>> linesdata = vertexer.getLinesData();
-    //     std::vector<std::array<float, 4>> centroidsData = vertexer.getCentroids();
-    //     std::vector<o2::its::Line> lines = vertexer.getLines();
-    //     std::vector<o2::its::Tracklet> c01 = vertexer.getTracklets01();
-    //     std::vector<o2::its::Tracklet> c12 = vertexer.getTracklets12();
-    //     std::array<std::vector<o2::its::Cluster>, 3> clusters = vertexer.getClusters();
-    //     std::vector<std::array<float, 7>> dtlambdas = vertexer.getDeltaTanLambdas();
-    //
-    //     for (auto& line : lines)
-    //       tracklets.Fill(line.originPoint[0], line.originPoint[1], line.originPoint[2], line.cosinesDirector[0], line.cosinesDirector[1], line.cosinesDirector[2],
-    //                      o2::its::Line::getDistanceFromPoint(line, std::array<float, 3>{ 0.f, 0.f, 0.f }), o2::its::Line::getDCA(line, zAxis));
-    //     for (int i{ 0 }; i < static_cast<int>(c01.size()); ++i) {
-    //       comb01.Fill(c01[i].tanLambda, c01[i].phiCoordinate);
-    //       clusPhi01.Fill(clusters[0][c01[i].firstClusterIndex].phiCoordinate, clusters[1][c01[i].secondClusterIndex].phiCoordinate);
-    //     }
-    //     for (int i{ 0 }; i < static_cast<int>(c12.size()); ++i) {
-    //       comb12.Fill(c12[i].tanLambda, c12[i].phiCoordinate);
-    //       clusPhi12.Fill(clusters[1][c12[i].firstClusterIndex].phiCoordinate, clusters[2][c12[i].secondClusterIndex].phiCoordinate);
-    //     }
-    //     for (auto& delta : dtlambdas) {
-    //       trackdeltaTanLambdas.Fill(delta.data());
-    //     }
-    //     for (auto& centroid : centroidsData) {
-    //       auto cdata = centroid.data();
-    //       centroids.Fill(roFrame, cdata[0], cdata[1], cdata[2], cdata[3]);
-    //     }
-    //     for (auto& linedata: linesdata) {
-    //       linesData.Fill(linedata.data());
-    //     }
-    //
+    // vertexer.processLines();
+    // std::vector<std::array<float, 6>> linesdata = vertexer.getLinesData();
+    // std::vector<std::array<float, 4>> centroidsData = vertexer.getCentroids();
+    // std::vector<o2::its::Line> lines = vertexer.getLines();
+    // std::vector<o2::its::Tracklet> c01 = vertexer.getTracklets01();
+    // std::vector<o2::its::Tracklet> c12 = vertexer.getTracklets12();
+    // std::array<std::vector<o2::its::Cluster>, 3> clusters = vertexer.getClusters();
+    // std::vector<std::array<float, 8>> dtlambdas = vertexer.getDeltaTanLambdas();
+    // for (auto& line : lines)
+    //   tracklets.Fill(line.originPoint[0], line.originPoint[1], line.originPoint[2], line.cosinesDirector[0], line.cosinesDirector[1], line.cosinesDirector[2],
+    //                  o2::its::Line::getDistanceFromPoint(line, std::array<float, 3>{ 0.f, 0.f, 0.f }), o2::its::Line::getDCA(line, zAxis));
+    // for (int i{ 0 }; i < static_cast<int>(c01.size()); ++i) {
+    //   comb01.Fill(c01[i].tanLambda, c01[i].phiCoordinate);
+    //   clusPhi01.Fill(clusters[0][c01[i].firstClusterIndex].phiCoordinate, clusters[1][c01[i].secondClusterIndex].phiCoordinate);
+    // }
+    // for (int i{ 0 }; i < static_cast<int>(c12.size()); ++i) {
+    //   comb12.Fill(c12[i].tanLambda, c12[i].phiCoordinate);
+    //   clusPhi12.Fill(clusters[1][c12[i].firstClusterIndex].phiCoordinate, clusters[2][c12[i].secondClusterIndex].phiCoordinate);
+    // }
+    // for (auto& delta : dtlambdas) {
+    //   trackdeltaTanLambdas.Fill(delta.data());
+    // }
+    // for (auto& centroid : centroidsData) {
+    //   auto cdata = centroid.data();
+    //   centroids.Fill(roFrame, cdata[0], cdata[1], cdata[2], cdata[3]);
+    // }
+    // for (auto& linedata : linesdata) {
+    //   linesData.Fill(linedata.data());
+    // }
     vertexer.findVertices();
     vertexer.dumpTraits();
     // std::cout << " - TOTAL elapsed time: " << total << "ms." << std::endl;
     std::vector<Vertex> vertITS = vertexer.exportVertices();
+    numVerts.Fill((int)vertITS.size()); 
     verticesITS->swap(vertITS);
     // std::array<float,3> trueVertex{mcHeader->GetX(),mcHeader->GetY(),mcHeader->GetZ()}; // UNCOMMENT TO GET THE MC VERTEX POS FOR CURRENT ROFRAME
     outTree.Fill();
+    // break;
   }
 
   outTree.Write();
-  //   tracklets.Write();
-  //   comb01.Write();
-  //   comb12.Write();
-  //   clusPhi01.Write();
-  //   clusPhi12.Write();
-  //   trackdeltaTanLambdas.Write();
-  //   centroids.Write();
+  numVerts.Write();
+  // tracklets.Write();
+  // comb01.Write();
+  // comb12.Write();
+  // clusPhi01.Write();
+  // clusPhi12.Write();
+  // trackdeltaTanLambdas.Write();
+  // centroids.Write();
   // linesData.Write();
   outputfile->Close();
   return 0;


### PR DESCRIPTION
Hi @a-kieffer,
I sorted out few things, notably:
- [x] Move Indextable printout to a separate `dumpIndexTable()` function
- [x] Move simple clusters generator into `o2::index_table_utils`
- [x] Generalise simple generator being able to get `phi` and `z` division as parameters (helix clusters no more :)) 
- [x] I also fixed the montecarlo label generation in simple cluster
To do:
 - [x] Improve simple generator to cover all the Z range
See also upcoming PR on your AliceVertexeFinding repository.

No need to merge immediately, we can discuss it today.

Cheers,
Matteo 